### PR TITLE
deploy with consul 1.16

### DIFF
--- a/Dockerfile-consul
+++ b/Dockerfile-consul
@@ -1,6 +1,7 @@
-FROM consul:latest
+FROM hashicorp/consul:latest
 
-RUN wget https://releases.hashicorp.com/consul/1.6.1/consul_1.6.1_linux_amd64.zip -O /tmp/consul.zip
+RUN whoami
+RUN wget https://releases.hashicorp.com/consul/1.16.0/consul_1.16.0_linux_amd64.zip -O /tmp/consul.zip
 RUN unzip /tmp/consul.zip -d /tmp
 RUN mv /tmp/consul /usr/local/bin/consul
 

--- a/docker-compose-v2.yml
+++ b/docker-compose-v2.yml
@@ -12,12 +12,12 @@ services:
       MESSAGE: "Service V2"
     networks:
       vpcbr:
-        ipv4_address: 10.5.0.5
+        ipv4_address: 10.12.0.5
   api_proxy_v2:
-    image: nicholasjackson/consul-envoy:v1.6.1-v0.10.0
+    image: nicholasjackson/consul-envoy:1.13.7-contrib-debug-v1.26.0
     environment:
-      CONSUL_HTTP_ADDR: 10.5.0.2:8500
-      CONSUL_GRPC_ADDR: 10.5.0.2:8502
+      CONSUL_HTTP_ADDR: 10.12.0.2:8500
+      CONSUL_GRPC_ADDR: 10.12.0.2:8502
       SERVICE_CONFIG: /config/api_v2.json
     volumes:
       - "./service_config:/config"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 8500:8500
     networks:
       vpcbr:
-        ipv4_address: 10.5.0.2
+        ipv4_address: 10.12.0.2
 
   # Define web service and envoy sidecar proxy
   web:
@@ -28,14 +28,14 @@ services:
       HTTP_CLIENT_KEEP_ALIVES: "false"
     networks:
       vpcbr:
-        ipv4_address: 10.5.0.3
+        ipv4_address: 10.12.0.3
     ports:
       - 9090:9090
   web_envoy:
-    image: nicholasjackson/consul-envoy:v1.6.1-v0.10.0
+    image: nicholasjackson/consul-envoy:1.13.7-contrib-debug-v1.26.0
     environment:
-      CONSUL_HTTP_ADDR: 10.5.0.2:8500
-      CONSUL_GRPC_ADDR: 10.5.0.2:8502
+      CONSUL_HTTP_ADDR: 10.12.0.2:8500
+      CONSUL_GRPC_ADDR: 10.12.0.2:8502
       SERVICE_CONFIG: /config/web.json
     volumes:
       - "./service_config:/config"
@@ -50,12 +50,12 @@ services:
       MESSAGE: "Service V1"
     networks:
       vpcbr:
-        ipv4_address: 10.5.0.4
+        ipv4_address: 10.12.0.4
   api_proxy_v1:
-    image: nicholasjackson/consul-envoy:v1.6.1-v0.10.0
+    image: nicholasjackson/consul-envoy:1.13.7-contrib-debug-v1.26.0
     environment:
-      CONSUL_HTTP_ADDR: 10.5.0.2:8500
-      CONSUL_GRPC_ADDR: 10.5.0.2:8502
+      CONSUL_HTTP_ADDR: 10.12.0.2:8500
+      CONSUL_GRPC_ADDR: 10.12.0.2:8502
       SERVICE_CONFIG: /config/api_v1.json
     volumes:
       - "./service_config:/config"
@@ -67,4 +67,4 @@ networks:
     driver: bridge
     ipam:
      config:
-       - subnet: 10.5.0.0/16
+       - subnet: 10.12.0.0/16

--- a/l7_config/api_service_router.json
+++ b/l7_config/api_service_router.json
@@ -1,0 +1,36 @@
+{
+  "kind": "service-router",
+  "name": "api",
+  "routes": [
+    {
+      "match": {
+        "HTTP": {
+          "header": [
+          {
+            "Name": "x-canary",
+            "Exact": "1"
+          }
+         ]
+        }
+      },
+      "destination": {
+        "ServiceSubset": "v1"
+      }
+    },
+    {
+      "match": {
+        "HTTP": {
+          "header": [
+          {
+            "Name": "x-canary",
+            "Exact": "2"
+          }
+         ]
+        }
+      },
+      "destination": {
+        "ServiceSubset": "v2"
+      }
+    }
+  ]
+}

--- a/l7_config/web_defaults.json
+++ b/l7_config/web_defaults.json
@@ -1,0 +1,5 @@
+{
+  "kind": "service-defaults",
+  "name": "web",
+  "protocol": "http"
+}

--- a/service_config/api_v1.json
+++ b/service_config/api_v1.json
@@ -6,14 +6,14 @@
     "meta": {
       "version": "1"
     },
-    "address": "10.5.0.4",
+    "address": "10.12.0.4",
     "port": 9090,
     "connect": { 
       "sidecar_service": {
         "port": 20000,
         "check": {
           "name": "Connect Envoy Sidecar",
-          "tcp": "10.5.0.4:20000",
+          "tcp": "10.12.0.4:20000",
           "interval": "10s"
         }
       }

--- a/service_config/api_v2.json
+++ b/service_config/api_v2.json
@@ -6,14 +6,14 @@
     "meta": {
       "version": "2"
     },
-    "address": "10.5.0.5",
+    "address": "10.12.0.5",
     "port": 9090,
     "connect": { 
       "sidecar_service": {
         "port": 20000,
         "check": {
           "name": "Connect Envoy Sidecar",
-          "tcp": "10.5.0.5:20000",
+          "tcp": "10.12.0.5:20000",
           "interval": "10s"
         }
       }

--- a/service_config/web.json
+++ b/service_config/web.json
@@ -2,14 +2,14 @@
   "service": {
     "name": "web",
     "id":"web-v1",
-    "address": "10.5.0.3",
+    "address": "10.12.0.3",
     "port": 9090,
     "connect": { 
       "sidecar_service": {
         "port": 20000,
         "check": {
           "name": "Connect Envoy Sidecar",
-          "tcp": "10.5.0.3:20000",
+          "tcp": "10.12.0.3:20000",
           "interval": "10s"
         },
         "proxy": {


### PR DESCRIPTION
## Notes on Hashicorp Tutorial
1.  Clone the repo
    ```
    $ git clone git@github.com:drewby08/consul-demo-traffic-splitting.git
    ```

2. Find and replace IP addresses starting with 10.5.* with 10.12 or something else not used on our network

3. Modify `Dockerfile-consul` to refer to new Consul image publishing location
    ```
    FROM hashicorp/consul:latest
    ```

4. Export ENV vars for build to work
   `export DOCKER_BUILDKIT=0`
    `export COMPOSE_DOCKER_CLI_BUILD=0`
6. `docker-compose up --build`
